### PR TITLE
Specify query handler strategy

### DIFF
--- a/asset-transfer-basic/rest-api-typescript/src/fabric.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/fabric.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  DefaultQueryHandlerStrategies,
+  Gateway,
+  GatewayOptions,
+  Contract,
+  Wallets,
+} from 'fabric-network';
+
+import * as config from './config';
+
+export const getContract = async (): Promise<Contract> => {
+  const wallet = await Wallets.newInMemoryWallet();
+
+  const x509Identity = {
+    credentials: {
+      certificate: config.certificate,
+      privateKey: config.privateKey,
+    },
+    mspId: config.mspId,
+    type: 'X.509',
+  };
+  await wallet.put(config.identityName, x509Identity);
+
+  const gateway = new Gateway();
+
+  const connectOptions: GatewayOptions = {
+    wallet,
+    identity: config.identityName,
+    discovery: { enabled: true, asLocalhost: config.asLocalHost },
+    queryHandlerOptions: {
+      timeout: 3,
+      strategy: DefaultQueryHandlerStrategies.PREFER_MSPID_SCOPE_ROUND_ROBIN,
+    },
+  };
+
+  await gateway.connect(config.connectionProfile, connectOptions);
+
+  const network = await gateway.getNetwork(config.channelName);
+  const contract = network.getContract(config.chaincodeName);
+
+  return contract;
+};

--- a/asset-transfer-basic/rest-api-typescript/src/server.ts
+++ b/asset-transfer-basic/rest-api-typescript/src/server.ts
@@ -6,11 +6,10 @@ import helmet from 'helmet';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import express, { Application, NextFunction, Request, Response } from 'express';
 import pinoMiddleware from 'pino-http';
-import { Gateway, GatewayOptions, Contract, Wallets } from 'fabric-network';
 
-import * as config from './config';
 import { logger } from './logger';
 import { assetsRouter } from './assets.router';
+import { getContract } from './fabric';
 
 const { BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND, OK } = StatusCodes;
 
@@ -91,35 +90,4 @@ export const createServer = async (): Promise<Application> => {
   });
 
   return app;
-};
-
-// TODO should this go in a fabric.ts file?
-
-const getContract = async (): Promise<Contract> => {
-  const wallet = await Wallets.newInMemoryWallet();
-
-  const x509Identity = {
-    credentials: {
-      certificate: config.certificate,
-      privateKey: config.privateKey,
-    },
-    mspId: config.mspId,
-    type: 'X.509',
-  };
-  await wallet.put(config.identityName, x509Identity);
-
-  const gateway = new Gateway();
-
-  const gatewayOpts: GatewayOptions = {
-    wallet,
-    identity: config.identityName,
-    discovery: { enabled: true, asLocalhost: config.asLocalHost },
-  };
-
-  await gateway.connect(config.connectionProfile, gatewayOpts);
-
-  const network = await gateway.getNetwork(config.channelName);
-  const contract = network.getContract(config.chaincodeName);
-
-  return contract;
 };


### PR DESCRIPTION
Avoid load on a single peer by specifying the PREFER_MSPID_SCOPE_ROUND_ROBIN
strategy

Signed-off-by: James Taylor <jamest@uk.ibm.com>